### PR TITLE
fix: запрет добавления расхода через ввод числа для роли viewer

### DIFF
--- a/handlers/expense.py
+++ b/handlers/expense.py
@@ -512,9 +512,19 @@ async def direct_amount_handler(update: Update, context: ContextTypes.DEFAULT_TY
     """
     Обрабатывает прямой ввод суммы без команды
     """
+    from utils.permissions import Permission, has_permission
+
     user_id = update.effective_user.id
     text = update.message.text
-    project_id = context.user_data.get('active_project_id')
+    project_id = await helpers.get_active_project_id(user_id, context)
+
+    # Проверяем право добавления расхода до показа категорий
+    if not await has_permission(user_id, project_id, Permission.ADD_EXPENSE):
+        await update.message.reply_text(
+            "❌ У вас нет прав на добавление расходов в этом проекте.\n"
+            "Роль «Наблюдатель» позволяет только просматривать данные."
+        )
+        return ConversationHandler.END
 
     # Проверяем, похоже ли сообщение на сумму
     try:


### PR DESCRIPTION
Обработчик direct_amount_handler (ввод вида "50") не проверял права пользователя перед показом выбора категории. Наблюдатель мог ввести число, выбрать категорию и добавить расход в обход ограничений.

Добавлена проверка Permission.ADD_EXPENSE в начало обработчика — аналогично add_command и text_handler. Также исправлено получение project_id: теперь используется helpers.get_active_project_id вместо прямого обращения к context.user_data.