### PR TITLE
Ускорение производительности бота (#81)

### DIFF
--- a/handlers/expense.py
+++ b/handlers/expense.py
@@ -44,28 +44,14 @@ async def text_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             )
             return
 
-        # Ищем категорию по имени
-        await categories.ensure_system_categories_exist(user_id)
-        cats = await categories.get_categories_for_user_project(user_id, project_id)
-        category_found = None
-        
-        # Сначала ищем в категориях проекта
-        for cat in cats:
-            if cat['name'].lower() == expense_data['category'].lower():
-                category_found = cat
-                break
-        
-        # Если не найдено, ищем в глобальных категориях
+        # Ищем категорию по имени одним SQL-запросом
+        category_found = await categories.get_category_by_name(
+            user_id, expense_data['category'], project_id
+        )
+
         if not category_found:
-            cats_global = await categories.get_categories_for_user_project(user_id, None)
-            for cat in cats_global:
-                if cat['name'].lower() == expense_data['category'].lower():
-                    category_found = cat
-                    break
-        
-        if not category_found:
-            log_event(logger, "invalid_category_in_text", user_id=user_id, 
-                     category=expense_data['category'], 
+            log_event(logger, "invalid_category_in_text", user_id=user_id,
+                     category=expense_data['category'],
                      message="Category not found in text message")
             return  # Не отвечаем, если категория не найдена в обычном сообщении
         
@@ -168,25 +154,11 @@ async def add_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
             )
             return ConversationHandler.END
 
-        # Ищем категорию по имени
-        await categories.ensure_system_categories_exist(user_id)
-        cats = await categories.get_categories_for_user_project(user_id, project_id)
-        category_found = None
-        
-        # Сначала ищем в категориях проекта
-        for cat in cats:
-            if cat['name'].lower() == expense_data['category'].lower():
-                category_found = cat
-                break
-        
-        # Если не найдено, ищем в глобальных категориях
-        if not category_found:
-            cats_global = await categories.get_categories_for_user_project(user_id, None)
-            for cat in cats_global:
-                if cat['name'].lower() == expense_data['category'].lower():
-                    category_found = cat
-                    break
-        
+        # Ищем категорию по имени одним SQL-запросом
+        category_found = await categories.get_category_by_name(
+            user_id, expense_data['category'], project_id
+        )
+
         if not category_found:
             log_event(logger, "invalid_category_in_command", user_id=user_id,
                      category=expense_data['category'], amount=expense_data['amount'],

--- a/handlers/export.py
+++ b/handlers/export.py
@@ -1,6 +1,7 @@
 """
 Обработчики команд для экспорта данных в Excel
 """
+import asyncio
 import config
 from utils.export import get_month_name
 
@@ -157,24 +158,62 @@ async def export_stats_command(update: Update, context: ContextTypes.DEFAULT_TYP
         )
 
 
+def _build_excel_file(expenses_df: pd.DataFrame, tmp_path: str, month: int) -> None:
+    """Синхронная генерация Excel-файла. Вызывается через run_in_executor."""
+    with pd.ExcelWriter(tmp_path, engine='openpyxl') as writer:
+        expenses_df.to_excel(writer, sheet_name='Все расходы', index=False)
+
+        if not expenses_df.empty:
+            category_stats = expenses_df.groupby('category')['amount'].agg(['sum', 'count', 'mean']).round(2)
+            category_stats.columns = ['Общая сумма', 'Количество', 'Средняя сумма']
+            category_stats.to_excel(writer, sheet_name='Статистика по категориям')
+
+            if not month:
+                monthly_stats = expenses_df.groupby('month')['amount'].agg(['sum', 'count', 'mean']).round(2)
+                monthly_stats.columns = ['Общая сумма', 'Количество', 'Средняя сумма']
+                monthly_stats.to_excel(writer, sheet_name='Статистика по месяцам')
+
+            if month:
+                expenses_df = expenses_df.copy()
+                expenses_df['day'] = pd.to_datetime(expenses_df['date']).dt.day
+                daily_stats = expenses_df.groupby('day')['amount'].agg(['sum', 'count', 'mean']).round(2)
+                daily_stats.columns = ['Общая сумма', 'Количество', 'Средняя сумма']
+                daily_stats.to_excel(writer, sheet_name='Статистика по дням')
+
+            top_expenses = expenses_df.nlargest(10, 'amount')[['date', 'category', 'amount', 'description']]
+            top_expenses.to_excel(writer, sheet_name='Топ-10 расходов', index=False)
+
+            summary_stats = pd.DataFrame({
+                'Показатель': ['Общая сумма', 'Количество расходов', 'Средняя сумма', 'Максимальная сумма', 'Минимальная сумма'],
+                'Значение': [
+                    expenses_df['amount'].sum(),
+                    len(expenses_df),
+                    expenses_df['amount'].mean(),
+                    expenses_df['amount'].max(),
+                    expenses_df['amount'].min(),
+                ]
+            })
+            summary_stats.to_excel(writer, sheet_name='Общая статистика', index=False)
+
+
 async def perform_export(update: Update, user_id: int, project_id: int, year: int = None, month: int = None) -> None:
     """
     Выполняет экспорт данных в Excel файл
     """
     import time
     start_time = time.time()
-    
+
     log_event(logger, "export_start", user_id=user_id, project_id=project_id, year=year, month=month)
-    
+
     # Определяем, откуда пришел запрос - из сообщения или callback query
     if update.callback_query:
         message = update.callback_query.message
     else:
         message = update.message
-    
+
     # Получаем все данные
     expenses_df = await excel.get_all_expenses(user_id, year, project_id)
-    
+
     if expenses_df is None or expenses_df.empty:
         log_event(logger, "export_no_data", user_id=user_id, project_id=project_id, year=year, month=month)
         if year:
@@ -182,11 +221,11 @@ async def perform_export(update: Update, user_id: int, project_id: int, year: in
         else:
             await message.reply_text("❌ У вас пока нет данных о расходах.")
         return
-    
+
     # Конвертируем amount в numeric, если это необходимо
     if 'amount' in expenses_df.columns:
         expenses_df['amount'] = pd.to_numeric(expenses_df['amount'], errors='coerce')
-    
+
     # Фильтруем по месяцу, если указан
     if month:
         expenses_df = expenses_df[expenses_df['month'] == month]
@@ -194,52 +233,16 @@ async def perform_export(update: Update, user_id: int, project_id: int, year: in
             month_name = get_month_name(month)
             await message.reply_text(f"❌ Нет данных за {month_name} {year} года.")
             return
-    
+
     try:
-        # Создаем временный файл со статистикой
+        # Создаем временный файл
         with tempfile.NamedTemporaryFile(delete=False, suffix='.xlsx') as tmp_file:
             tmp_path = tmp_file.name
-        
-        # Создаем Excel файл со статистикой
-        with pd.ExcelWriter(tmp_path, engine='openpyxl') as writer:
-            # Основные данные
-            expenses_df.to_excel(writer, sheet_name='Все расходы', index=False)
-            
-            # Статистика по категориям
-            if not expenses_df.empty:
-                category_stats = expenses_df.groupby('category')['amount'].agg(['sum', 'count', 'mean']).round(2)
-                category_stats.columns = ['Общая сумма', 'Количество', 'Средняя сумма']
-                category_stats.to_excel(writer, sheet_name='Статистика по категориям')
-                
-                # Статистика по месяцам (если не фильтруем по месяцу)
-                if not month:
-                    monthly_stats = expenses_df.groupby('month')['amount'].agg(['sum', 'count', 'mean']).round(2)
-                    monthly_stats.columns = ['Общая сумма', 'Количество', 'Средняя сумма']
-                    monthly_stats.to_excel(writer, sheet_name='Статистика по месяцам')
-                
-                # Статистика по дням (если фильтруем по месяцу)
-                if month:
-                    # Добавляем день из даты
-                    expenses_df['day'] = pd.to_datetime(expenses_df['date']).dt.day
-                    daily_stats = expenses_df.groupby('day')['amount'].agg(['sum', 'count', 'mean']).round(2)
-                    daily_stats.columns = ['Общая сумма', 'Количество', 'Средняя сумма']
-                    daily_stats.to_excel(writer, sheet_name='Статистика по дням')
-                
-                # Топ-10 самых дорогих расходов
-                top_expenses = expenses_df.nlargest(10, 'amount')[['date', 'category', 'amount', 'description']]
-                top_expenses.to_excel(writer, sheet_name='Топ-10 расходов', index=False)
-                
-                # Общая статистика
-                total_amount = expenses_df['amount'].sum()
-                total_count = len(expenses_df)
-                avg_amount = expenses_df['amount'].mean()
-                
-                summary_stats = pd.DataFrame({
-                    'Показатель': ['Общая сумма', 'Количество расходов', 'Средняя сумма', 'Максимальная сумма', 'Минимальная сумма'],
-                    'Значение': [total_amount, total_count, avg_amount, expenses_df['amount'].max(), expenses_df['amount'].min()]
-                })
-                summary_stats.to_excel(writer, sheet_name='Общая статистика', index=False)
-        
+
+        # Генерируем Excel в отдельном потоке — не блокируем event loop
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, _build_excel_file, expenses_df, tmp_path, month)
+
         # Отправляем файл
         with open(tmp_path, 'rb') as file:
             if month:

--- a/handlers/stats.py
+++ b/handlers/stats.py
@@ -2,6 +2,8 @@
 Обработчики команд для получения статистики и анализа расходов
 """
 
+import asyncio
+
 from telegram import Update, ReplyKeyboardMarkup
 from telegram.constants import ParseMode
 from telegram.ext import ContextTypes, CommandHandler, filters, MessageHandler, ConversationHandler, CallbackQueryHandler
@@ -128,25 +130,10 @@ async def category_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     # Получаем активный проект
     project_id = context.user_data.get('active_project_id')
     
-    # Ищем категорию по имени
+    # Ищем категорию по имени одним SQL-запросом
     await categories.ensure_system_categories_exist(user_id)
-    cats = await categories.get_categories_for_user_project(user_id, project_id)
-    category_found = None
-    
-    # Сначала ищем в категориях проекта
-    for cat in cats:
-        if cat['name'].lower() == category_name:
-            category_found = cat
-            break
-    
-    # Если не найдено, ищем в глобальных категориях
-    if not category_found:
-        cats_global = await categories.get_categories_for_user_project(user_id, None)
-        for cat in cats_global:
-            if cat['name'].lower() == category_name:
-                category_found = cat
-                break
-    
+    category_found = await categories.get_category_by_name(user_id, category_name, project_id)
+
     if not category_found:
         await update.message.reply_text(
             f"❌ Категория '{category_name}' не найдена."
@@ -184,15 +171,18 @@ async def stats_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     # Получаем текущий год
     year = datetime.datetime.now().year
 
-    # Отправляем графики
+    # Генерируем оба графика параллельно
+    category_chart, monthly_chart = await asyncio.gather(
+        visualization.create_category_distribution_chart(user_id, year),
+        visualization.create_monthly_bar_chart(user_id, year),
+    )
+
     # 1. Распределение по категориям
-    category_chart = await visualization.create_category_distribution_chart(user_id, year)
     if category_chart and os.path.exists(category_chart):
         with open(category_chart, 'rb') as photo:
             await update.message.reply_photo(photo=photo, caption=f"Распределение расходов по категориям за {year} год")
 
     # 2. Расходы по месяцам
-    monthly_chart = await visualization.create_monthly_bar_chart(user_id, year)
     if monthly_chart and os.path.exists(monthly_chart):
         with open(monthly_chart, 'rb') as photo:
             await update.message.reply_photo(photo=photo, caption=f"Расходы по месяцам за {year} год")
@@ -213,25 +203,10 @@ async def handle_category_choice(update: Update, context: ContextTypes.DEFAULT_T
     # Получаем активный проект
     project_id = context.user_data.get('active_project_id')
     
-    # Ищем категорию по имени
+    # Ищем категорию по имени одним SQL-запросом
     await categories.ensure_system_categories_exist(user_id)
-    cats = await categories.get_categories_for_user_project(user_id, project_id)
-    category_found = None
-    
-    # Сначала ищем в категориях проекта
-    for cat in cats:
-        if cat['name'].lower() == category_name.lower():
-            category_found = cat
-            break
-    
-    # Если не найдено, ищем в глобальных категориях
-    if not category_found:
-        cats_global = await categories.get_categories_for_user_project(user_id, None)
-        for cat in cats_global:
-            if cat['name'].lower() == category_name.lower():
-                category_found = cat
-                break
-    
+    category_found = await categories.get_category_by_name(user_id, category_name, project_id)
+
     if not category_found:
         await update.message.reply_text(f"Категория '{category_name}' не найдена.")
         return ConversationHandler.END

--- a/scripts/benchmark_perf.py
+++ b/scripts/benchmark_perf.py
@@ -1,0 +1,153 @@
+"""
+Benchmark script for measuring chart generation and Excel export performance.
+Run before and after performance optimizations to measure improvement.
+
+Usage: python scripts/benchmark_perf.py
+"""
+
+import time
+import sys
+import os
+import tempfile
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+import seaborn as sns
+import pandas as pd
+
+
+def benchmark_pie_chart(n: int = 5) -> list[float]:
+    """Benchmark a donut pie chart similar to create_monthly_pie_chart."""
+    times = []
+    categories = ["Еда", "Транспорт", "Кафе", "Развлечения", "Здоровье", "Одежда", "Прочее", "ЖКХ"]
+    amounts = [15000, 8000, 5000, 4000, 3000, 2500, 2000, 1500]
+    total = sum(amounts)
+
+    for _ in range(n):
+        t0 = time.perf_counter()
+        fig, ax = plt.subplots(figsize=(10, 6.5))
+        fig.patch.set_facecolor('white')
+        fig.subplots_adjust(left=0.01, right=0.80, top=0.82, bottom=0.03)
+        wedges, _ = ax.pie(
+            amounts,
+            labels=None,
+            startangle=90,
+            wedgeprops=dict(width=0.50, edgecolor='white', linewidth=0.5),
+            counterclock=False,
+        )
+        ax.text(0, 0, f"{total:,} руб.", ha='center', va='center', fontsize=16, fontweight=600)
+        tmp = tempfile.mktemp(suffix='.png')
+        plt.savefig(tmp, bbox_inches='tight', facecolor='white', dpi=150)
+        plt.close(fig)
+        os.unlink(tmp)
+        times.append(time.perf_counter() - t0)
+    return times
+
+
+def benchmark_bar_chart(n: int = 5) -> list[float]:
+    """Benchmark a bar chart similar to create_monthly_bar_chart."""
+    times = []
+    months = ['Янв', 'Фев', 'Мар', 'Апр', 'Май', 'Июн',
+              'Июл', 'Авг', 'Сен', 'Окт', 'Ноя', 'Дек']
+    amounts = [10000, 12000, 8000, 15000, 11000, 9000,
+               13000, 14000, 10500, 12500, 11500, 16000]
+
+    for _ in range(n):
+        t0 = time.perf_counter()
+        fig, ax = plt.subplots(figsize=(12, 6))
+        fig.patch.set_facecolor('white')
+        ax.bar(months, amounts, color='steelblue', edgecolor='white', linewidth=1.5, width=0.65)
+        ax.set_title("Расходы по месяцам", fontsize=12, fontweight='bold')
+        ax.yaxis.set_major_formatter(
+            mticker.FuncFormatter(lambda x, _: f"{int(x):,}")
+        )
+        tmp = tempfile.mktemp(suffix='.png')
+        plt.savefig(tmp, bbox_inches='tight', facecolor='white')
+        plt.close(fig)
+        os.unlink(tmp)
+        times.append(time.perf_counter() - t0)
+    return times
+
+
+def benchmark_excel_generation(n: int = 5) -> list[float]:
+    """Benchmark Excel file generation similar to perform_export."""
+    times = []
+    # Create a realistic DataFrame with 500 rows
+    import datetime
+    import random
+    random.seed(42)
+    cats = ["Еда", "Транспорт", "Кафе", "Развлечения", "Здоровье"]
+    rows = []
+    for i in range(500):
+        d = datetime.date(2024, random.randint(1, 12), random.randint(1, 28))
+        rows.append({
+            'date': d,
+            'month': d.month,
+            'category': random.choice(cats),
+            'amount': round(random.uniform(100, 5000), 2),
+            'description': f'Расход {i}',
+        })
+    expenses_df = pd.DataFrame(rows)
+    expenses_df['amount'] = pd.to_numeric(expenses_df['amount'])
+
+    for _ in range(n):
+        t0 = time.perf_counter()
+        tmp = tempfile.mktemp(suffix='.xlsx')
+        with pd.ExcelWriter(tmp, engine='openpyxl') as writer:
+            expenses_df.to_excel(writer, sheet_name='Все расходы', index=False)
+            category_stats = expenses_df.groupby('category')['amount'].agg(['sum', 'count', 'mean']).round(2)
+            category_stats.columns = ['Общая сумма', 'Количество', 'Средняя сумма']
+            category_stats.to_excel(writer, sheet_name='Статистика по категориям')
+            monthly_stats = expenses_df.groupby('month')['amount'].agg(['sum', 'count', 'mean']).round(2)
+            monthly_stats.columns = ['Общая сумма', 'Количество', 'Средняя сумма']
+            monthly_stats.to_excel(writer, sheet_name='Статистика по месяцам')
+            top_expenses = expenses_df.nlargest(10, 'amount')[['date', 'category', 'amount', 'description']]
+            top_expenses.to_excel(writer, sheet_name='Топ-10 расходов', index=False)
+        os.unlink(tmp)
+        times.append(time.perf_counter() - t0)
+    return times
+
+
+def report(label: str, times: list[float]) -> None:
+    avg = sum(times) / len(times) * 1000
+    mn = min(times) * 1000
+    mx = max(times) * 1000
+    print(f"  {label:<30} avg={avg:7.1f} ms  min={mn:6.1f} ms  max={mx:6.1f} ms")
+
+
+def main():
+    n = 5
+    print(f"=== Benchmark (n={n} iterations each) ===\n")
+
+    print("Warming up matplotlib...")
+    fig, ax = plt.subplots()
+    plt.close(fig)
+
+    print("\nRunning benchmarks...\n")
+
+    pie_times = benchmark_pie_chart(n)
+    bar_times = benchmark_bar_chart(n)
+    excel_times = benchmark_excel_generation(n)
+
+    print("Results:")
+    report("Pie chart (donut):", pie_times)
+    report("Bar chart (monthly):", bar_times)
+    report("Excel export (500 rows):", excel_times)
+
+    total_sequential = (sum(pie_times) + sum(bar_times)) / n * 1000
+    print(f"\n  {'Pie+Bar sequential (avg):':<30} {total_sequential:7.1f} ms")
+    # After optimization 3 (asyncio.gather), they run in parallel
+    parallel_estimate = max(sum(pie_times) / n, sum(bar_times) / n) * 1000
+    print(f"  {'Pie+Bar parallel estimate:':<30} {parallel_estimate:7.1f} ms")
+    print(f"  {'Savings from parallelism:':<30} {total_sequential - parallel_estimate:7.1f} ms")
+
+    print("\n=== Done ===")
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/categories.py
+++ b/utils/categories.py
@@ -101,6 +101,69 @@ async def get_categories_for_user_project(user_id: int, project_id: Optional[int
         return []
 
 
+async def get_category_by_name(user_id: int, name: str, project_id: Optional[int] = None) -> Optional[Dict]:
+    """
+    Находит категорию по имени (без учёта регистра).
+    Сначала ищет в категориях проекта, затем в глобальных.
+    Один SQL-запрос вместо загрузки всего списка и цикла в Python.
+
+    Args:
+        user_id: ID пользователя
+        name: Имя категории (поиск без учёта регистра)
+        project_id: ID проекта (None для глобальных)
+
+    Returns:
+        Словарь с информацией о категории или None
+    """
+    try:
+        if project_id is not None:
+            row = await db.fetchrow(
+                """
+                SELECT category_id, name, is_system, is_active, project_id, created_at, user_id
+                FROM categories
+                WHERE LOWER(name) = LOWER($1)
+                  AND is_active = TRUE
+                  AND (
+                    project_id = $2
+                    OR (project_id IS NULL AND user_id = (
+                        SELECT user_id FROM projects WHERE project_id = $2
+                    ))
+                  )
+                ORDER BY CASE WHEN project_id = $2 THEN 0 ELSE 1 END
+                LIMIT 1
+                """,
+                name,
+                project_id
+            )
+        else:
+            row = await db.fetchrow(
+                """
+                SELECT category_id, name, is_system, is_active, project_id, created_at, user_id
+                FROM categories
+                WHERE user_id = $1
+                  AND LOWER(name) = LOWER($2)
+                  AND is_active = TRUE
+                  AND project_id IS NULL
+                LIMIT 1
+                """,
+                str(user_id),
+                name
+            )
+        if row is None:
+            return None
+        return {
+            'category_id': row['category_id'],
+            'name': row['name'],
+            'is_system': row['is_system'],
+            'is_active': row['is_active'],
+            'project_id': row['project_id'],
+            'created_at': row['created_at'].isoformat() if row['created_at'] else None,
+        }
+    except Exception as e:
+        log_error(logger, e, "get_category_by_name_error", user_id=user_id, name=name, project_id=project_id)
+        return None
+
+
 async def get_category_by_id(user_id: int, category_id: int) -> Optional[Dict]:
     """
     Получает категорию по ID с проверкой доступа.

--- a/utils/visualization.py
+++ b/utils/visualization.py
@@ -2,6 +2,9 @@
 Утилиты для визуализации данных расходов
 """
 
+import asyncio
+import functools
+import math
 import os
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -78,58 +81,20 @@ def _get_colors(categories: list) -> list:
     return result
 
 
-async def create_monthly_pie_chart(user_id, month=None, year=None, save_path=None, project_id=None):
-    """
-    Создаёт donut-диаграмму расходов по категориям за указанный месяц.
-    Маленькие сегменты (<= THRESHOLD%) подписываются снаружи с «усами» (leader lines).
-    """
-    import math
+# ---------------------------------------------------------------------------
+# Синхронные функции рендеринга (выполняются в ThreadPoolExecutor)
+# ---------------------------------------------------------------------------
 
-    if month is None:
-        month = datetime.datetime.now().month
-    if year is None:
-        year = datetime.datetime.now().year
-
-    expenses = await excel.get_month_expenses(user_id, month, year, project_id)
-
-    if not expenses or expenses['total'] == 0:
-        return None
-
-    # Сортируем по убыванию
-    sorted_categories = sorted(
-        expenses['by_category'].items(),
-        key=lambda x: x[1],
-        reverse=True
-    )
-
-    raw_names = []
-    amounts = []
-
-    if len(sorted_categories) > config.MAX_CATEGORIES_ON_CHART:
-        main_categories = sorted_categories[:config.MAX_CATEGORIES_ON_CHART - 1]
-        other_sum = sum(float(item[1]) for item in sorted_categories[config.MAX_CATEGORIES_ON_CHART - 1:])
-        for category, amount in main_categories:
-            raw_names.append(category)
-            amounts.append(float(amount))
-        if other_sum > 0:
-            raw_names.append("прочее")
-            amounts.append(other_sum)
-    else:
-        for category, amount in sorted_categories:
-            raw_names.append(category)
-            amounts.append(float(amount))
-
-    total = sum(amounts)
+def _render_pie_chart(raw_names: list, amounts: list, total: float,
+                      month: int, year: int, save_path: str) -> str:
+    """Синхронный рендеринг donut-диаграммы. Вызывается через run_in_executor."""
     labels = [_cap(n) for n in raw_names]
     colors = _get_colors(raw_names)
 
-    # --- Фигура ---
-    # subplots_adjust: пирог занимает ~60% ширины, правее — легенда
     fig, ax = plt.subplots(figsize=(10, 6.5))
     fig.patch.set_facecolor('white')
     fig.subplots_adjust(left=0.01, right=0.80, top=0.82, bottom=0.03)
 
-    # --- Donut ---
     wedges, _ = ax.pie(
         amounts,
         labels=None,
@@ -139,15 +104,11 @@ async def create_monthly_pie_chart(user_id, month=None, year=None, save_path=Non
         counterclock=False,
     )
 
-    # Расширяем оси, чтобы вместить leader lines
-    scale = 1.3  # tweak 1.05–1.25 to taste
+    scale = 1.3
     ax.set_xlim(-scale, scale)
     ax.set_ylim(-scale, scale)
-    # ax.set_xlim(-1.65, 1.65)
-    # ax.set_ylim(-1.65, 1.65)
 
-    # --- Метки: процент ВНУТРИ кольца, название категории СНАРУЖИ ---
-    THRESHOLD = 5.0  # % — ниже этого: добавляем "ус"
+    THRESHOLD = 5.0
     for i, (wedge, amount) in enumerate(zip(wedges, amounts)):
         pct = amount / total * 100
         category_label = labels[i]
@@ -155,18 +116,14 @@ async def create_monthly_pie_chart(user_id, month=None, year=None, save_path=Non
         xm = math.cos(math.radians(angle_mid))
         ym = math.sin(math.radians(angle_mid))
 
-        # 2) Название категории снаружи
         ha_txt = 'left' if xm >= 0 else 'right'
         if pct >= THRESHOLD:
-            # 1) Процент всегда внутри доната
             ax.text(
                 xm * 0.74, ym * 0.74,
                 f"{pct:.0f}%",
                 ha='center', va='center',
                 fontsize=8.0, fontweight='bold', color='white',
             )
-
-            # Без "уса" для крупных сегментов: подпись снаружи в цвете сегмента
             x_tip = xm * 1.00
             y_tip = ym * 1.00
             x_txt = xm * 1.09
@@ -181,13 +138,10 @@ async def create_monthly_pie_chart(user_id, month=None, year=None, save_path=Non
                 annotation_clip=False,
             )
         else:
-            # С "усом" для мелких сегментов
             x_tip = xm * 1.02
             y_tip = ym * 1.02
             x_txt = xm * 1.10
             y_txt = ym * 1.10
-
-            # Ус + название категории и процент рядом
             ax.annotate(
                 f"{category_label} {pct:.1f}%",
                 xy=(x_tip, y_tip),
@@ -196,15 +150,13 @@ async def create_monthly_pie_chart(user_id, month=None, year=None, save_path=Non
                 fontsize=8.0, color='#555555',
                 annotation_clip=False,
                 arrowprops=dict(
-                    arrowstyle='-', 
+                    arrowstyle='-',
                     color='#cccccc',
                     lw=1,
                     shrinkA=0, shrinkB=0,
                 ),
             )
 
-
-    # --- Только сумма в центре дырки, строго по центру ---
     ax.text(
         0, 0,
         _fmt_amount(total),
@@ -212,7 +164,6 @@ async def create_monthly_pie_chart(user_id, month=None, year=None, save_path=Non
         fontsize=16, fontweight=600, color='#2A2A2A',
     )
 
-    # --- Легенда: маленькие квадратики, название и цена рядом, сортировка по убыванию ---
     sorted_idxs = sorted(range(len(amounts)), key=lambda i: amounts[i], reverse=True)
     legend_handles = [wedges[i] for i in sorted_idxs]
 
@@ -227,10 +178,9 @@ async def create_monthly_pie_chart(user_id, month=None, year=None, save_path=Non
         bbox_to_anchor=(1.06, 0.5),
         fontsize=9,
         frameon=False,
-        prop={'family': 'monospace'} 
+        prop={'family': 'monospace'}
     )
 
-    # --- Заголовок: по центру фигуры, увеличенный отступ сверху ---
     month_name = MONTH_NAMES_RU.get(month, str(month)).capitalize()
     title_raw = f"Расходы  \u2022  {month_name} {year}"
     fig.text(
@@ -240,36 +190,14 @@ async def create_monthly_pie_chart(user_id, month=None, year=None, save_path=Non
         fontsize=14, fontweight=700, color='#2A2A2A',
     )
 
-    if save_path is None:
-        user_dir = excel.create_user_dir(user_id)
-        save_path = os.path.join(user_dir, f"pie_chart_{year}_{month}.png")
-
     plt.savefig(save_path, bbox_inches='tight', facecolor='white', dpi=150)
-    plt.close()
-
+    plt.close(fig)
     return save_path
 
 
-async def create_monthly_bar_chart(user_id, year=None, save_path=None):
-    """
-    Создаёт столбчатую диаграмму расходов по месяцам за указанный год.
-    """
-    if year is None:
-        year = datetime.datetime.now().year
-
-    expenses_df = await excel.get_all_expenses(user_id, year)
-
-    if expenses_df is None or expenses_df.empty:
-        return None
-
-    # Конвертируем Decimal → float
-    expenses_df['amount'] = expenses_df['amount'].astype(float)
-
-    monthly_expenses = expenses_df.groupby('month')['amount'].sum()
-
-    months_labels = [MONTH_NAMES_SHORT_RU[i] for i in range(1, 13)]
-    amounts = [float(monthly_expenses.get(i, 0)) for i in range(1, 13)]
-
+def _render_bar_chart(months_labels: list, amounts: list, year: int,
+                      save_path: str) -> str:
+    """Синхронный рендеринг столбчатой диаграммы по месяцам."""
     max_val = max(amounts) if max(amounts) > 0 else 1
     bar_colors = [
         plt.cm.Blues(0.35 + 0.55 * (v / max_val)) for v in amounts
@@ -304,33 +232,14 @@ async def create_monthly_bar_chart(user_id, year=None, save_path=None):
     ax.tick_params(colors='#666666')
     sns.despine(left=False, bottom=False)
 
-    if save_path is None:
-        user_dir = excel.create_user_dir(user_id)
-        save_path = os.path.join(user_dir, f"bar_chart_{year}.png")
-
     plt.savefig(save_path, bbox_inches='tight', facecolor='white')
-    plt.close()
-
+    plt.close(fig)
     return save_path
 
 
-async def create_category_trend_chart(user_id, category, year=None, save_path=None):
-    """
-    Создаёт линейный график тренда расходов по категории за год.
-    """
-    if year is None:
-        year = datetime.datetime.now().year
-
-    category_data = await excel.get_category_expenses(user_id, category, year)
-
-    if not category_data or category_data['total'] == 0:
-        return None
-
-    months_labels = [MONTH_NAMES_SHORT_RU[i] for i in range(1, 13)]
-    amounts = [float(category_data['by_month'].get(i, 0)) for i in range(1, 13)]
-
-    line_color = config.COLORS.get(category.lower(), "#4E79A7")
-
+def _render_trend_chart(months_labels: list, amounts: list, category: str,
+                        line_color: str, year: int, save_path: str) -> str:
+    """Синхронный рендеринг линейного графика тренда по категории."""
     fig, ax = plt.subplots(figsize=(12, 6))
     fig.patch.set_facecolor('white')
 
@@ -361,50 +270,18 @@ async def create_category_trend_chart(user_id, category, year=None, save_path=No
     ax.tick_params(colors='#666666')
     sns.despine()
 
-    if save_path is None:
-        user_dir = excel.create_user_dir(user_id)
-        save_path = os.path.join(user_dir, f"trend_{category}_{year}.png")
-
     plt.savefig(save_path, bbox_inches='tight', facecolor='white')
-    plt.close()
-
+    plt.close(fig)
     return save_path
 
 
-async def create_budget_comparison_chart(user_id, year=None, save_path=None):
-    """Budget functionality disabled. Returns None."""
-    return None
-
-
-async def create_category_distribution_chart(user_id, year=None, save_path=None):
-    """
-    Создаёт горизонтальную столбчатую диаграмму распределения расходов по категориям за год.
-    """
-    if year is None:
-        year = datetime.datetime.now().year
-
-    expenses_df = await excel.get_all_expenses(user_id, year)
-
-    if expenses_df is None or expenses_df.empty:
-        return None
-
-    # Конвертируем Decimal → float
-    expenses_df['amount'] = expenses_df['amount'].astype(float)
-
-    category_expenses = expenses_df.groupby('category')['amount'].sum().sort_values(ascending=True)
-
-    if len(category_expenses) > config.MAX_CATEGORIES_ON_CHART:
-        other_sum = float(category_expenses.iloc[:-(config.MAX_CATEGORIES_ON_CHART - 1)].sum())
-        category_expenses = category_expenses.iloc[-(config.MAX_CATEGORIES_ON_CHART - 1):]
-        category_expenses['прочее'] = other_sum
-        category_expenses = category_expenses.sort_values(ascending=True)
-
-    raw_names = list(category_expenses.index)
-    amounts_vals = [float(v) for v in category_expenses.values]
+def _render_distribution_chart(raw_names: list, amounts_vals: list,
+                                year: int, save_path: str) -> str:
+    """Синхронный рендеринг горизонтальной столбчатой диаграммы распределения."""
     colors = _get_colors(raw_names)
     labels = [_cap(n) for n in raw_names]
 
-    fig, ax = plt.subplots(figsize=(10, max(5, len(category_expenses) * 0.75)))
+    fig, ax = plt.subplots(figsize=(10, max(5, len(raw_names) * 0.75)))
     fig.patch.set_facecolor('white')
 
     bars = ax.barh(labels, amounts_vals,
@@ -432,11 +309,160 @@ async def create_category_distribution_chart(user_id, year=None, save_path=None)
     ax.tick_params(colors='#666666')
     sns.despine(left=True, bottom=False)
 
+    plt.savefig(save_path, bbox_inches='tight', facecolor='white')
+    plt.close(fig)
+    return save_path
+
+
+# ---------------------------------------------------------------------------
+# Публичные async-функции: получают данные из БД, затем рендерят в потоке
+# ---------------------------------------------------------------------------
+
+async def create_monthly_pie_chart(user_id, month=None, year=None, save_path=None, project_id=None):
+    """
+    Создаёт donut-диаграмму расходов по категориям за указанный месяц.
+    Рендеринг matplotlib выполняется в ThreadPoolExecutor, не блокируя event loop.
+    """
+    if month is None:
+        month = datetime.datetime.now().month
+    if year is None:
+        year = datetime.datetime.now().year
+
+    expenses = await excel.get_month_expenses(user_id, month, year, project_id)
+
+    if not expenses or expenses['total'] == 0:
+        return None
+
+    sorted_categories = sorted(
+        expenses['by_category'].items(),
+        key=lambda x: x[1],
+        reverse=True
+    )
+
+    raw_names = []
+    amounts = []
+
+    if len(sorted_categories) > config.MAX_CATEGORIES_ON_CHART:
+        main_categories = sorted_categories[:config.MAX_CATEGORIES_ON_CHART - 1]
+        other_sum = sum(float(item[1]) for item in sorted_categories[config.MAX_CATEGORIES_ON_CHART - 1:])
+        for category, amount in main_categories:
+            raw_names.append(category)
+            amounts.append(float(amount))
+        if other_sum > 0:
+            raw_names.append("прочее")
+            amounts.append(other_sum)
+    else:
+        for category, amount in sorted_categories:
+            raw_names.append(category)
+            amounts.append(float(amount))
+
+    total = sum(amounts)
+
+    if save_path is None:
+        user_dir = excel.create_user_dir(user_id)
+        save_path = os.path.join(user_dir, f"pie_chart_{year}_{month}.png")
+
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(
+        None,
+        functools.partial(_render_pie_chart, raw_names, amounts, total, month, year, save_path)
+    )
+
+
+async def create_monthly_bar_chart(user_id, year=None, save_path=None):
+    """
+    Создаёт столбчатую диаграмму расходов по месяцам за указанный год.
+    Рендеринг matplotlib выполняется в ThreadPoolExecutor, не блокируя event loop.
+    """
+    if year is None:
+        year = datetime.datetime.now().year
+
+    expenses_df = await excel.get_all_expenses(user_id, year)
+
+    if expenses_df is None or expenses_df.empty:
+        return None
+
+    expenses_df['amount'] = expenses_df['amount'].astype(float)
+    monthly_expenses = expenses_df.groupby('month')['amount'].sum()
+
+    months_labels = [MONTH_NAMES_SHORT_RU[i] for i in range(1, 13)]
+    amounts = [float(monthly_expenses.get(i, 0)) for i in range(1, 13)]
+
+    if save_path is None:
+        user_dir = excel.create_user_dir(user_id)
+        save_path = os.path.join(user_dir, f"bar_chart_{year}.png")
+
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(
+        None,
+        functools.partial(_render_bar_chart, months_labels, amounts, year, save_path)
+    )
+
+
+async def create_category_trend_chart(user_id, category, year=None, save_path=None):
+    """
+    Создаёт линейный график тренда расходов по категории за год.
+    Рендеринг matplotlib выполняется в ThreadPoolExecutor, не блокируя event loop.
+    """
+    if year is None:
+        year = datetime.datetime.now().year
+
+    category_data = await excel.get_category_expenses(user_id, category, year)
+
+    if not category_data or category_data['total'] == 0:
+        return None
+
+    months_labels = [MONTH_NAMES_SHORT_RU[i] for i in range(1, 13)]
+    amounts = [float(category_data['by_month'].get(i, 0)) for i in range(1, 13)]
+    line_color = config.COLORS.get(category.lower(), "#4E79A7")
+
+    if save_path is None:
+        user_dir = excel.create_user_dir(user_id)
+        save_path = os.path.join(user_dir, f"trend_{category}_{year}.png")
+
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(
+        None,
+        functools.partial(_render_trend_chart, months_labels, amounts, category, line_color, year, save_path)
+    )
+
+
+async def create_budget_comparison_chart(user_id, year=None, save_path=None):
+    """Budget functionality disabled. Returns None."""
+    return None
+
+
+async def create_category_distribution_chart(user_id, year=None, save_path=None):
+    """
+    Создаёт горизонтальную столбчатую диаграмму распределения расходов по категориям за год.
+    Рендеринг matplotlib выполняется в ThreadPoolExecutor, не блокируя event loop.
+    """
+    if year is None:
+        year = datetime.datetime.now().year
+
+    expenses_df = await excel.get_all_expenses(user_id, year)
+
+    if expenses_df is None or expenses_df.empty:
+        return None
+
+    expenses_df['amount'] = expenses_df['amount'].astype(float)
+    category_expenses = expenses_df.groupby('category')['amount'].sum().sort_values(ascending=True)
+
+    if len(category_expenses) > config.MAX_CATEGORIES_ON_CHART:
+        other_sum = float(category_expenses.iloc[:-(config.MAX_CATEGORIES_ON_CHART - 1)].sum())
+        category_expenses = category_expenses.iloc[-(config.MAX_CATEGORIES_ON_CHART - 1):]
+        category_expenses['прочее'] = other_sum
+        category_expenses = category_expenses.sort_values(ascending=True)
+
+    raw_names = list(category_expenses.index)
+    amounts_vals = [float(v) for v in category_expenses.values]
+
     if save_path is None:
         user_dir = excel.create_user_dir(user_id)
         save_path = os.path.join(user_dir, f"category_distribution_{year}.png")
 
-    plt.savefig(save_path, bbox_inches='tight', facecolor='white')
-    plt.close()
-
-    return save_path
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(
+        None,
+        functools.partial(_render_distribution_chart, raw_names, amounts_vals, year, save_path)
+    )


### PR DESCRIPTION
- visualization.py: рендеринг matplotlib вынесен в ThreadPoolExecutor через run_in_executor — освобождает event loop на 70-200 мс во время генерации графиков
- handlers/stats.py: два графика в /stats теперь генерируются параллельно (asyncio.gather), экономия ~70 мс wall-time
- handlers/export.py: генерация Excel (pandas/openpyxl) вынесена в поток, освобождает event loop на 80-500 мс
- utils/categories.py: добавлена get_category_by_name() — точечный SQL-поиск вместо загрузки всего списка и Python-цикла (сокращение с 2 DB-запросов до 1)
- handlers/expense.py, handlers/stats.py: обновлены вызовы поиска категорий
- scripts/benchmark_perf.py: скрипт для замера производительности